### PR TITLE
feat(macos): #36 hide app from Dock and show in menu bar only

### DIFF
--- a/decentpaste-app/src-tauri/src/lib.rs
+++ b/decentpaste-app/src-tauri/src/lib.rs
@@ -66,6 +66,10 @@ pub fn run() {
             // Setup system tray and window close interception (desktop only)
             #[cfg(not(any(target_os = "android", target_os = "ios")))]
             {
+                // macOS: Hide from Dock, show only in menu bar (system tray)
+                #[cfg(target_os = "macos")]
+                app.set_activation_policy(tauri::ActivationPolicy::Accessory);
+
                 if let Err(e) = tray::setup_tray(&app_handle) {
                     error!("Failed to setup system tray: {}", e);
                 }


### PR DESCRIPTION
Summary

  - Add macOS "Menu Bar Only" mode so the app never appears in the Dock
  - App is now only accessible via the system tray (menu bar icon)
  - Addresses user request for a less intrusive desktop experience

  Test plan

  - Run yarn tauri dev on macOS
  - Verify app does NOT appear in the Dock
  - Verify app IS visible in the menu bar (system tray)
  - Verify clicking tray icon shows/hides the main window
  - Verify "Quit" from tray menu properly exits the app
  - Verify Cmd+Tab does NOT show the app
  - Verify Linux/Windows builds are unaffected (no compilation errors)

See the issue #36 