### PR TITLE
feat(app): add global shortcut to show and focus main window #40

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1090,6 +1090,7 @@ dependencies = [
  "tauri-plugin-clipboard-manager",
  "tauri-plugin-decentsecret",
  "tauri-plugin-decentshare",
+ "tauri-plugin-global-shortcut",
  "tauri-plugin-opener",
  "tauri-plugin-os",
  "tauri-plugin-process",
@@ -1981,6 +1982,24 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "global-hotkey"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9247516746aa8e53411a0db9b62b0e24efbcf6a76e0ba73e5a91b512ddabed7"
+dependencies = [
+ "crossbeam-channel",
+ "keyboard-types",
+ "objc2",
+ "objc2-app-kit",
+ "once_cell",
+ "serde",
+ "thiserror 2.0.18",
+ "windows-sys 0.59.0",
+ "x11rb",
+ "xkeysym",
+]
 
 [[package]]
 name = "gobject-sys"
@@ -5987,6 +6006,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-global-shortcut"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "424af23c7e88d05e4a1a6fc2c7be077912f8c76bd7900fd50aa2b7cbf5a2c405"
+dependencies = [
+ "global-hotkey",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tauri-plugin-opener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7850,6 +7884,12 @@ dependencies = [
  "libc",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "xkeysym"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xml-rs"

--- a/decentpaste-app/src-tauri/Cargo.toml
+++ b/decentpaste-app/src-tauri/Cargo.toml
@@ -72,3 +72,4 @@ async-trait = "0.1"
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-single-instance = "2"
 tauri-plugin-autostart = "2"
+tauri-plugin-global-shortcut = "2"

--- a/decentpaste-app/src-tauri/capabilities/desktop.json
+++ b/decentpaste-app/src-tauri/capabilities/desktop.json
@@ -4,5 +4,12 @@
   "description": "Desktop-only capabilities",
   "windows": ["main"],
   "platforms": ["linux", "macOS", "windows"],
-  "permissions": ["autostart:allow-enable", "autostart:allow-disable", "autostart:allow-is-enabled"]
+  "permissions": [
+    "autostart:allow-enable",
+    "autostart:allow-disable",
+    "autostart:allow-is-enabled",
+    "global-shortcut:allow-register",
+    "global-shortcut:allow-unregister",
+    "global-shortcut:allow-is-registered"
+  ]
 }

--- a/decentpaste-app/src-tauri/src/lib.rs
+++ b/decentpaste-app/src-tauri/src/lib.rs
@@ -93,6 +93,34 @@ pub fn run() {
                     MacosLauncher::LaunchAgent,
                     None,
                 ))?;
+
+                // Global shortcut to show/focus window (CommandOrControl+Shift+D)
+                use tauri_plugin_global_shortcut::{
+                    Builder as GlobalShortcutBuilder, ShortcutState,
+                };
+                match GlobalShortcutBuilder::new()
+                    .with_shortcuts(["CommandOrControl+Shift+D"])
+                {
+                    Ok(builder) => {
+                        if let Err(e) = app.handle().plugin(
+                            builder
+                                .with_handler(|app, _shortcut, event| {
+                                    if event.state == ShortcutState::Pressed {
+                                        if let Some(window) =
+                                            app.get_webview_window("main")
+                                        {
+                                            let _ = window.show();
+                                            let _ = window.set_focus();
+                                        }
+                                    }
+                                })
+                                .build(),
+                        ) {
+                            warn!("Failed to register global shortcut: {}", e);
+                        }
+                    }
+                    Err(e) => warn!("Failed to parse global shortcut: {}", e),
+                }
             }
 
             // Initialize app state


### PR DESCRIPTION
#40
- Integrated global shortcut (`CommandOrControl+Shift+D`) support using `tauri-plugin-global-shortcut`.
- Implemented logic to show and focus the main window upon shortcut activation.
- Updated permissions and dependencies to include `global-shortcut` functionality.