### PR TITLE
docs: update bump-version workflow for iOS Info.plist handling

### DIFF
--- a/.claude/skills/bump-version/SKILL.md
+++ b/.claude/skills/bump-version/SKILL.md
@@ -16,11 +16,14 @@ Update version (x.x.x) across all config files.
 | `decentpaste-app/src-tauri/tauri.conf.json`              | `"version"`                                 |
 | `website/downloads.json`                                 | `version`, `tag` (v-prefix), asset URLs     |
 | `decentpaste-app/src-tauri/gen/apple/...project.pbxproj` | `MARKETING_VERSION` (if iOS project exists) |
+| `decentpaste-app/src-tauri/gen/apple/decentpaste-app_iOS/Info.plist` | `CFBundleShortVersionString` (if file exists) |
 
 ## Workflow
 
 1. Read current version from `tauri.conf.json`
 2. Ask new version (validate: `^\d+\.\d+\.\d+$`)
 3. Edit all 4 files (`replace_all: true` for downloads.json URLs)
-4. If `gen/apple/` exists, update Share Extension: `sed -i '' 's/MARKETING_VERSION = OLD;/MARKETING_VERSION = NEW;/g' ...project.pbxproj`
+4. If `gen/apple/` exists:
+   - Update Share Extension: `sed -i '' 's/MARKETING_VERSION = OLD;/MARKETING_VERSION = NEW;/g' ...project.pbxproj`
+   - Update iOS Info.plist: replace `<string>OLD</string>` with `<string>NEW</string>` for `CFBundleShortVersionString` in `gen/apple/decentpaste-app_iOS/Info.plist`
 5. List updated files, remind to commit

--- a/decentpaste-app/src-tauri/gen/apple/decentpaste-app_iOS/Info.plist
+++ b/decentpaste-app/src-tauri/gen/apple/decentpaste-app_iOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.8.0</string>
+	<string>0.8.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
- Documented version update process for `CFBundleShortVersionString` in `gen/apple/decentpaste-app_iOS/Info.plist`.