### PR TITLE
fix: real clipboard size limit, vault lock semantics, and an echo race

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1219,6 +1219,7 @@ dependencies = [
  "anyhow",
  "argon2",
  "async-trait",
+ "base64 0.23.1",
  "chrono",
  "futures",
  "hex",

--- a/decentpaste-app/src-tauri/Cargo.toml
+++ b/decentpaste-app/src-tauri/Cargo.toml
@@ -40,6 +40,7 @@ argon2.workspace = true
 rand.workspace = true
 sha2.workspace = true
 hex.workspace = true
+base64.workspace = true
 x25519-dalek.workspace = true
 zeroize.workspace = true
 

--- a/decentpaste-app/src-tauri/src/clipboard/monitor.rs
+++ b/decentpaste-app/src-tauri/src/clipboard/monitor.rs
@@ -60,7 +60,7 @@ impl ClipboardMonitor {
                 // Note: On Android/iOS, the Rust clipboard API may not work for reading.
                 #[cfg(not(any(target_os = "android", target_os = "ios")))]
                 {
-                    const MAX_CLIPBOARD_SIZE: usize = 1024 * 1024; // 1MB limit
+                    use crate::network::MAX_CLIPBOARD_CONTENT_BYTES as MAX_CLIPBOARD_SIZE;
                     match app_handle.clipboard().read_text() {
                         Ok(text) => {
                             if !text.is_empty() && text.len() <= MAX_CLIPBOARD_SIZE {

--- a/decentpaste-app/src-tauri/src/commands.rs
+++ b/decentpaste-app/src-tauri/src/commands.rs
@@ -1314,7 +1314,7 @@ async fn share_clipboard_content(
     use tauri::Emitter;
 
     // Limit clipboard content size to prevent memory exhaustion (1MB max)
-    const MAX_CLIPBOARD_SIZE: usize = 1024 * 1024;
+    use crate::network::MAX_CLIPBOARD_CONTENT_BYTES as MAX_CLIPBOARD_SIZE;
     if content.len() > MAX_CLIPBOARD_SIZE {
         return Err(DecentPasteError::InvalidInput(
             "Clipboard content too large (max 1MB)".into(),

--- a/decentpaste-app/src-tauri/src/commands.rs
+++ b/decentpaste-app/src-tauri/src/commands.rs
@@ -944,10 +944,27 @@ pub async fn unlock_vault(
 pub async fn lock_vault(app_handle: AppHandle, state: State<'_, AppState>) -> Result<()> {
     use tracing::info;
 
+    use zeroize::Zeroize;
+
     info!("Locking vault");
 
     // Flush current state to vault before locking (safety net - data should already be persisted)
     let _ = state.flush_all_to_vault().await;
+
+    // Stop network and clipboard services. Without this, sync continues behind the lock
+    // screen and every received entry is dropped, because flushing needs an open vault.
+    {
+        let tx = state.network_command_tx.write().await.take();
+        if let Some(tx) = tx {
+            let _ = tx.send(NetworkCommand::Shutdown).await;
+        }
+    }
+    if let Some(monitor) = state.clipboard_monitor.write().await.take() {
+        monitor.stop().await;
+    }
+
+    // Clear the start guard so unlocking brings the services back up.
+    crate::mark_services_stopped();
 
     // Lock the vault (clears encryption key from memory)
     {
@@ -957,6 +974,31 @@ pub async fn lock_vault(app_handle: AppHandle, state: State<'_, AppState>) -> Re
         }
         *manager = None;
     }
+
+    // Wipe key material and plaintext history from memory - the lock is meaningless if
+    // the per-peer shared secrets and the device private key stay resident.
+    {
+        let mut paired_peers = state.paired_peers.write().await;
+        for peer in paired_peers.iter_mut() {
+            peer.shared_secret.zeroize();
+        }
+        paired_peers.clear();
+    }
+    {
+        let mut device_identity = state.device_identity.write().await;
+        if let Some(identity) = device_identity.as_mut() {
+            if let Some(private_key) = identity.private_key.as_mut() {
+                private_key.zeroize();
+            }
+        }
+        *device_identity = None;
+    }
+    state.clipboard_history.write().await.clear();
+    state.message_buffers.write().await.clear();
+    state.ready_peers.write().await.clear();
+    state.discovered_peers.write().await.clear();
+    state.pairing_sessions.write().await.clear();
+
 
     // Update status
     {

--- a/decentpaste-app/src-tauri/src/lib.rs
+++ b/decentpaste-app/src-tauri/src/lib.rs
@@ -1020,6 +1020,11 @@ pub async fn start_network_services(
                                         let is_foreground = true;
 
                                         if is_foreground {
+                                            // Prevent echo: register the hash *before* writing,
+                                            // or a poll landing between the two reads it back as
+                                            // a local change and re-broadcasts it to the sender.
+                                            clipboard_monitor.set_last_hash(hash.clone()).await;
+
                                             // Update local clipboard directly
                                             if let Err(e) =
                                                 clipboard::monitor::set_clipboard_content(
@@ -1029,10 +1034,6 @@ pub async fn start_network_services(
                                             {
                                                 error!("Failed to set clipboard: {}", e);
                                             }
-
-                                            // Prevent echo: tell the monitor about this hash
-                                            // so it won't treat it as a local change
-                                            clipboard_monitor.set_last_hash(hash.clone()).await;
                                         } else {
                                             // Mobile background: queue clipboard silently (no notification)
                                             // Clipboard will be copied when app resumes

--- a/decentpaste-app/src-tauri/src/lib.rs
+++ b/decentpaste-app/src-tauri/src/lib.rs
@@ -369,6 +369,26 @@ async fn initialize_app(
     Ok(())
 }
 
+/// Clears `SERVICES_STARTED` if `start_network_services` bails out before finishing, so a
+/// failed start does not leave the app permanently unable to bring networking up again.
+struct ServicesStartGuard {
+    armed: bool,
+}
+
+impl Drop for ServicesStartGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            SERVICES_STARTED.store(false, Ordering::SeqCst);
+        }
+    }
+}
+
+/// Mark network services as stopped so a later unlock starts them again.
+/// Called by `lock_vault` after it has torn the services down.
+pub fn mark_services_stopped() {
+    SERVICES_STARTED.store(false, Ordering::SeqCst);
+}
+
 /// Start network and clipboard services after vault is unlocked.
 /// This is called from unlock_vault/setup_vault commands.
 pub async fn start_network_services(
@@ -379,6 +399,10 @@ pub async fn start_network_services(
         warn!("Network services already started, skipping");
         return Ok(());
     }
+
+    // If anything below fails we must clear the flag, or the app can never start
+    // networking again for the rest of the process lifetime.
+    let mut start_guard = ServicesStartGuard { armed: true };
 
     let state = app_handle.state::<AppState>();
 
@@ -451,6 +475,12 @@ pub async fn start_network_services(
         .start(app_handle.clone(), clipboard_tx)
         .await;
     let clipboard_monitor_network = clipboard_monitor.clone();
+
+    // Keep a handle so locking the vault can stop the monitor
+    {
+        let mut stored = state.clipboard_monitor.write().await;
+        *stored = Some(clipboard_monitor.clone());
+    }
 
     // Handle clipboard changes - broadcast to network
     let app_handle_clipboard = app_handle.clone();
@@ -1343,6 +1373,7 @@ pub async fn start_network_services(
         }
     });
 
+    start_guard.armed = false;
     info!("Network services started successfully");
     Ok(())
 }

--- a/decentpaste-app/src-tauri/src/lib.rs
+++ b/decentpaste-app/src-tauri/src/lib.rs
@@ -1318,6 +1318,11 @@ pub async fn start_network_services(
                                         };
 
                                         if !already_has {
+                                            // Prevent echo: register the hash *before* writing,
+                                            // or a poll landing between the two reads it back as
+                                            // a local change and re-broadcasts it to the sender.
+                                            clipboard_monitor.set_last_hash(hash.clone()).await;
+
                                             // Set clipboard
                                             if let Err(e) =
                                                 clipboard::monitor::set_clipboard_content(
@@ -1327,9 +1332,6 @@ pub async fn start_network_services(
                                             {
                                                 error!("Failed to set synced clipboard: {}", e);
                                             }
-
-                                            // Prevent echo
-                                            clipboard_monitor.set_last_hash(hash.clone()).await;
 
                                             // Add to history with correct timestamp
                                             let entry = ClipboardEntry::new_remote(

--- a/decentpaste-app/src-tauri/src/lib.rs
+++ b/decentpaste-app/src-tauri/src/lib.rs
@@ -1095,6 +1095,17 @@ pub async fn start_network_services(
                     );
                 }
 
+                NetworkEvent::ClipboardSendFailed { id, reason } => {
+                    warn!("Clipboard {} was not delivered: {}", id, reason);
+                    let _ = app_handle_network.emit(
+                        "clipboard-send-failed",
+                        serde_json::json!({
+                            "id": id,
+                            "reason": reason,
+                        }),
+                    );
+                }
+
                 NetworkEvent::Error(error) => {
                     let _ = app_handle_network.emit("network-error", error);
                 }

--- a/decentpaste-app/src-tauri/src/network/behaviour.rs
+++ b/decentpaste-app/src-tauri/src/network/behaviour.rs
@@ -125,6 +125,7 @@ impl DecentPasteBehaviour {
             // This is important for quick clipboard sync after peer restart
             .heartbeat_interval(Duration::from_secs(1))
             .validation_mode(gossipsub::ValidationMode::Strict)
+            .max_transmit_size(super::protocol::GOSSIPSUB_MAX_TRANSMIT_SIZE)
             .message_id_fn(|message| {
                 // For clipboard messages: use the message's own UUID as the MessageId
                 // This makes each broadcast unique, allowing resending same content.

--- a/decentpaste-app/src-tauri/src/network/events.rs
+++ b/decentpaste-app/src-tauri/src/network/events.rs
@@ -86,6 +86,12 @@ pub enum NetworkEvent {
         id: String,
         peer_count: usize,
     },
+    /// A clipboard broadcast could not be published. Emitted so the user learns the copy
+    /// never left the device instead of it silently appearing synced.
+    ClipboardSendFailed {
+        id: String,
+        reason: String,
+    },
 
     // Status events
     StatusChanged(NetworkStatus),

--- a/decentpaste-app/src-tauri/src/network/mod.rs
+++ b/decentpaste-app/src-tauri/src/network/mod.rs
@@ -4,5 +4,7 @@ pub mod protocol;
 pub mod swarm;
 
 pub use events::{DiscoveredPeer, NetworkEvent, NetworkStatus};
-pub use protocol::{ClipboardMessage, PairingRequest, ProtocolMessage};
+pub use protocol::{
+    ClipboardMessage, PairingRequest, ProtocolMessage, MAX_CLIPBOARD_CONTENT_BYTES,
+};
 pub use swarm::{NetworkCommand, NetworkManager};

--- a/decentpaste-app/src-tauri/src/network/protocol.rs
+++ b/decentpaste-app/src-tauri/src/network/protocol.rs
@@ -1,6 +1,36 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+/// Largest clipboard content we will sync, in bytes.
+///
+/// This and [`GOSSIPSUB_MAX_TRANSMIT_SIZE`] are two halves of one budget: content is
+/// AES-GCM encrypted (+28 bytes), base64 encoded (~1.34x) and wrapped in a JSON envelope,
+/// so the wire size is roughly 1.4x the content. The transmit size must stay above that
+/// product or large copies fail to publish.
+pub const MAX_CLIPBOARD_CONTENT_BYTES: usize = 1024 * 1024;
+
+/// Maximum gossipsub RPC size. libp2p defaults to 64 KiB, which silently capped clipboard
+/// sync far below [`MAX_CLIPBOARD_CONTENT_BYTES`].
+pub const GOSSIPSUB_MAX_TRANSMIT_SIZE: usize = 2 * 1024 * 1024;
+
+/// Serializes `Vec<u8>` as a base64 string rather than a JSON array of decimal numbers.
+/// The array form costs ~3.6 wire bytes per payload byte; base64 costs ~1.34.
+mod base64_bytes {
+    use base64::Engine;
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(bytes: &[u8], serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&base64::engine::general_purpose::STANDARD.encode(bytes))
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Vec<u8>, D::Error> {
+        let encoded = String::deserialize(deserializer)?;
+        base64::engine::general_purpose::STANDARD
+            .decode(&encoded)
+            .map_err(serde::de::Error::custom)
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ProtocolMessage {
     Pairing(PairingMessage),
@@ -87,6 +117,7 @@ pub struct PairingConfirm {
 pub struct ClipboardMessage {
     pub id: String,
     pub content_hash: String,
+    #[serde(with = "base64_bytes")]
     pub encrypted_content: Vec<u8>,
     pub timestamp: DateTime<Utc>,
     pub origin_device_id: String,

--- a/decentpaste-app/src-tauri/src/network/swarm.rs
+++ b/decentpaste-app/src-tauri/src/network/swarm.rs
@@ -840,6 +840,13 @@ impl NetworkManager {
                     }
                     Err(e) => {
                         warn!("Failed to broadcast clipboard: {}", e);
+                        let _ = self
+                            .event_tx
+                            .send(NetworkEvent::ClipboardSendFailed {
+                                id: message.id,
+                                reason: e.to_string(),
+                            })
+                            .await;
                     }
                 }
             }

--- a/decentpaste-app/src-tauri/src/network/swarm.rs
+++ b/decentpaste-app/src-tauri/src/network/swarm.rs
@@ -22,6 +22,9 @@ use super::protocol::{ClipboardMessage, DeviceAnnounceMessage, PairingMessage, P
 pub enum NetworkCommand {
     StartListening,
     StopListening,
+    /// Tear down the swarm and end the manager task. Sent when the vault is locked so no
+    /// clipboard traffic continues behind the lock screen.
+    Shutdown,
     SendPairingRequest {
         peer_id: String,
         message: Vec<u8>,
@@ -198,6 +201,10 @@ impl NetworkManager {
 
                 // Handle commands
                 Some(command) = self.command_rx.recv() => {
+                    if matches!(command, NetworkCommand::Shutdown) {
+                        info!("Network manager shutting down");
+                        return;
+                    }
                     self.handle_command(command).await;
                 }
             }
@@ -1085,6 +1092,9 @@ impl NetworkManager {
                     paired_peer_addresses.len()
                 );
             }
+
+            // Handled in `run()`, which returns before dispatching here.
+            NetworkCommand::Shutdown => {}
 
             NetworkCommand::StartListening | NetworkCommand::StopListening => {
                 // Already handled during initialization

--- a/decentpaste-app/src-tauri/src/state.rs
+++ b/decentpaste-app/src-tauri/src/state.rs
@@ -52,6 +52,8 @@ pub struct AppState {
     pub vault_status: Arc<RwLock<VaultStatus>>,
     /// VaultManager instance for encrypted storage (only present when vault is open)
     pub vault_manager: Arc<RwLock<Option<VaultManager>>>,
+    /// Running clipboard monitor, kept so locking the vault can stop it.
+    pub clipboard_monitor: Arc<RwLock<Option<Arc<crate::clipboard::ClipboardMonitor>>>>,
 
     // =========================================================================
     // Connection Management State
@@ -95,6 +97,7 @@ impl AppState {
             ready_peers: Arc::new(RwLock::new(HashSet::new())), // No peers ready initially
             vault_status: Arc::new(RwLock::new(VaultStatus::NotSetup)), // Vault starts as not setup
             vault_manager: Arc::new(RwLock::new(None)), // No vault manager until unlocked
+            clipboard_monitor: Arc::new(RwLock::new(None)), // Set when services start
 
             // Connection management
             reconnect_in_progress: AtomicBool::new(false),

--- a/decentpaste-app/src/api/events.ts
+++ b/decentpaste-app/src/api/events.ts
@@ -2,6 +2,7 @@ import { listen, UnlistenFn } from '@tauri-apps/api/event';
 import type {
   ClipboardBroadcastPayload,
   ClipboardEntry,
+  ClipboardSendFailedPayload,
   DiscoveredPeer,
   NetworkStatus,
   PairingCompletePayload,
@@ -37,6 +38,7 @@ interface EventListeners {
   clipboardReceived: EventHandler<ClipboardEntry>[];
   clipboardSent: EventHandler<ClipboardEntry>[];
   clipboardBroadcast: EventHandler<ClipboardBroadcastPayload>[];
+  clipboardSendFailed: EventHandler<ClipboardSendFailedPayload>[];
   clipboardSyncedFromBackground: EventHandler<ClipboardSyncedFromBackgroundPayload>[];
   networkError: EventHandler<string>[];
   appMinimizedToTray: EventHandler<void>[];
@@ -57,6 +59,7 @@ class EventManager {
     clipboardReceived: [],
     clipboardSent: [],
     clipboardBroadcast: [],
+    clipboardSendFailed: [],
     clipboardSyncedFromBackground: [],
     networkError: [],
     appMinimizedToTray: [],
@@ -100,6 +103,9 @@ class EventManager {
       }),
       listen<ClipboardBroadcastPayload>('clipboard-broadcast', (e) => {
         this.listeners.clipboardBroadcast.forEach((fn) => fn(e.payload));
+      }),
+      listen<ClipboardSendFailedPayload>('clipboard-send-failed', (e) => {
+        this.listeners.clipboardSendFailed.forEach((fn) => fn(e.payload));
       }),
       listen<ClipboardSyncedFromBackgroundPayload>('clipboard-synced-from-background', (e) => {
         this.listeners.clipboardSyncedFromBackground.forEach((fn) => fn(e.payload));

--- a/decentpaste-app/src/api/types.ts
+++ b/decentpaste-app/src/api/types.ts
@@ -120,6 +120,11 @@ export interface ClipboardBroadcastPayload {
   peerCount: number;
 }
 
+export interface ClipboardSendFailedPayload {
+  id: string;
+  reason: string;
+}
+
 export interface PeerNameUpdatedPayload {
   peerId: string;
   deviceName: string;

--- a/decentpaste-app/src/app.ts
+++ b/decentpaste-app/src/app.ts
@@ -887,6 +887,10 @@ class App {
       store.addToast(`Network error: ${error}`, 'error');
     });
 
+    eventManager.on('clipboardSendFailed', (payload) => {
+      store.addToast(`Copy not synced: ${payload.reason}`, 'error');
+    });
+
     // Handle app minimized to tray (desktop only)
     eventManager.on('appMinimizedToTray', () => {
       store.set('isWindowVisible', false);


### PR DESCRIPTION
Three bugs, found and fixed inside a disposable Linux desktop that was running two real DecentPaste peers against each other.

DecentPaste is a P2P app, so its interesting behaviour only exists *between* two instances. Unit tests can't tell you whether a clipboard entry actually crossed the wire, and one laptop can't easily run two peers. So the whole run happened inside a throwaway [uremot](https://uremot.com) desktop instance: clone → build → run two paired peers → break things on purpose → fix → verify in the same place.

![Two DecentPaste peers on one disposable desktop](https://raw.githubusercontent.com/decentpaste/decentpaste/assets/uremot-e2e/img/01-hero.png)

> Left: the shell driving the test. Middle and right: two independent DecentPaste instances.
> The badges are the whole point — `Local` means the entry originated on that device, a
> device-name badge means it arrived from the peer. That's the only honest proof a message
> crossed the network, because both instances share one X11 clipboard.

---

## TL;DR

| # | Bug | Status |
|---|---|---|
| 1 | Clipboard over ~18 KB silently never syncs, and the UI reports success | ✅ fixed |
| 3 | Locking the vault doesn't stop syncing, and loses everything received while locked | ✅ fixed |
| 5 | `SERVICES_STARTED` never resets — a dead network stack can never restart | ✅ fixed (with #3) |
| 6 | Echo-guard race can bounce peer content back to the sender | ✅ fixed |
| 2 | Sync can wedge permanently between two connected peers | ❌ **open** — root-caused, see below |

`cargo check` ✅ · `cargo clippy` ✅ · `yarn build` ✅ · zero warnings.

---

## 1. The advertised 1 MB clipboard limit was really ~18 KB

Two places in the code promise 1 MB:

```rust
// clipboard/monitor.rs:63  and  commands.rs:1317
const MAX_CLIPBOARD_SIZE: usize = 1024 * 1024; // 1MB limit
```

The real ceiling, binary-searched against two live peers: **18,218 bytes synced, 18,250 bytes did not.**

Two things multiply into that number:

```mermaid
flowchart LR
    A["clipboard text<br/>N bytes"] --> B["AES-256-GCM<br/>+28 bytes"]
    B --> C["serde_json Vec&lt;u8&gt;<br/>'[72,101,108,...]'<br/><b>×3.6</b>"]
    C --> D{"gossipsub<br/>max_transmit_size<br/><b>64 KiB default</b>"}
    D -->|"N &gt; ~18.2 KB"| E["PublishError::MessageTooLarge<br/>warn! and nothing else"]
    D -->|"N ≤ ~18.2 KB"| F["delivered"]
```

`serde_json` renders `Vec<u8>` as a JSON array of decimal numbers, so every payload byte costs ~3.6 bytes on the wire. 65536 / 3.6 gives out right around 18.2 KB.

**The silent part is the actual bug.** The publish fails inside the swarm task, which only warned. Meanwhile the clipboard task counts a successful *channel send*, not a successful *publish*:

```rust
// lib.rs — before
if let Err(e) = network_cmd_tx_clipboard.send(NetworkCommand::BroadcastClipboard { .. }).await {
    error!("Failed to send clipboard to network: {}", e);
} else {
    broadcast_count += 1;          // <- counts the send, not the publish
}
...
if broadcast_count > 0 {
    // entry added to history, `clipboard-sent` emitted → looks synced
}
```

So the copy appeared in your history, the app said nothing, and it never left the machine.

![The bug, with the original logs](https://raw.githubusercontent.com/decentpaste/decentpaste/assets/uremot-e2e/img/02-bug.png)

**The fix** (`79c6976`):
- serialise `encrypted_content` as base64 — ~1.34 wire bytes/byte instead of ~3.6
- raise `max_transmit_size` to 2 MiB so 1 MB of text genuinely fits
- collapse the two duplicated `MAX_CLIPBOARD_SIZE` constants into one `MAX_CLIPBOARD_CONTENT_BYTES`, declared next to `GOSSIPSUB_MAX_TRANSMIT_SIZE` so the two halves of the budget stay visibly related
- add `NetworkEvent::ClipboardSendFailed` → `clipboard-send-failed` → an error toast

```rust
/// Serializes `Vec<u8>` as a base64 string rather than a JSON array of decimal numbers.
/// The array form costs ~3.6 wire bytes per payload byte; base64 costs ~1.34.
mod base64_bytes { /* ... */ }

#[serde(with = "base64_bytes")]
pub encrypted_content: Vec<u8>,
```

⚠️ **Breaking wire-format change.** A peer on this build and a peer on an older build cannot exchange clipboard messages. Worth deciding whether to bump the protocol version so mismatched peers fail cleanly rather than mysteriously.

---

## 3. "Locked" didn't mean locked

`lock_vault` cleared the vault encryption key and *nothing else*. Unlike `reset_vault`, it left `paired_peers` (holding the per-peer AES-256 shared secrets), `device_identity` (the X25519 private key) and `clipboard_history` resident in memory — and it never stopped the network or clipboard tasks.

Captured with **both** vaults locked:

```
20:15:39.573  B  Clipboard content changed, hash: c2266fa0
20:15:39.575  B  Broadcast clipboard message: 52e6b67f-…
20:15:39.583  A  Received clipboard message from 3f4f1eb6-…
20:15:39.583  A  WARN Cannot flush clipboard history: vault not open
```

Peer A received and decrypted clipboard content behind its own lock screen. And because flushing needs an open vault, everything that arrived while locked was dropped — the only trace a `WARN` nobody reads. Confirmed in the UI: after a lock and restart, ~12 minutes of history was simply gone.

**The fix** (`71bf757`) makes locking mean locking:

```mermaid
sequenceDiagram
    participant U as User
    participant C as lock_vault
    participant N as NetworkManager
    participant M as ClipboardMonitor
    U->>C: lock
    C->>C: flush_all_to_vault()
    C->>N: NetworkCommand::Shutdown
    N-->>C: task returns
    C->>M: stop()
    C->>C: drop VaultManager
    Note over C: only now is it safe to clear
    C->>C: zeroize secrets + clear state
    C->>C: mark_services_stopped()
```

**Ordering is load-bearing.** My first version cleared the in-memory state *before* dropping the vault manager — which means a flush racing the teardown would persist the emptied lists and **destroy the user's pairings**. Clearing only after the vault is closed makes every subsequent flush a no-op, so the clear physically cannot be written back.

This also fixes **#5**: `SERVICES_STARTED` now resets on lock, and a `ServicesStartGuard` clears it if `start_network_services` bails out early — so a failed start no longer leaves the process permanently unable to bring networking up.

Verified live, one instance, padlock button:

| step | before | after |
|---|---|---|
| monitor running before lock | yes | yes |
| network task on lock | still running | `Network manager shutting down` |
| clipboard watched while locked | yes — kept syncing | **0 changes seen** |
| peer secrets in memory | resident | zeroized |
| items received while locked | silently lost | n/a — nothing arrives |
| services after unlock | `already started, skipping` | restarted cleanly |
| **pairing survives the cycle** | — | **1 paired** ✅ |

---

## 6. The echo race — two lines, swapped

```diff
- set_clipboard_content(&app_handle_network, &content)?;   // write first
- clipboard_monitor.set_last_hash(hash.clone()).await;     // guard second
+ clipboard_monitor.set_last_hash(hash.clone()).await;     // guard first
+ set_clipboard_content(&app_handle_network, &content)?;
```

The monitor polls on its own task every 500 ms. A poll landing between those two statements reads the freshly written content, finds a hash it has never seen, and treats **peer content as a local change** — bouncing it back to the sender and adding a duplicate history entry with the wrong attribution.

**`set_last_hash` has two call sites, and the first pass only fixed one.** The other is the
`ContentResponse` handler that applies clipboard items recovered by offline sync, and it had the
same statements in the same wrong order. The monitor polls every 500 ms regardless of which path
produced the write, so the race there is identical — it is just rarer, because
`SYNC_MAX_BUFFER_SIZE = 1` (finding 13) keeps that path from carrying much traffic. Fixed in
`3d53510` with the same two-line swap.

Worth saying plainly: that second site was found by re-reading this PR *after* opening it, not by
the test run. The live reproduction exercised the gossipsub receive path only.

---

## Still open: sync can wedge permanently (#2)

Not fixed here, and I'd treat it as the next priority. After a burst of large clipboard items, gossipsub delivery dies in both directions and never recovers. Everything else looks healthy:

```
A: Broadcast clipboard message: 250a358e-…       <- app thinks it sent
   libp2p: Published message message_id=…        <- libp2p thinks it sent
B: (nothing)                                     <- never arrives
   yamux::connection::rtt: received pong         <- TCP alive
   Identified peer …: decentpaste/0.8.1/uremot-dev  <- identify alive
   HEARTBEAT: Mesh low. Topic contains: 0 needs: 6
   Peer couldn't consume messages: FailedMessages { publish: 1, timeout: 1 }
A: WARN Peer 12D3KooW…subrnw is slow
```

Reproduced deterministically 3×. Survives 10+ minutes and dozens of probes; only an app restart recovers it. `gossipsub::Event::SlowPeer` is currently handled with a bare `warn!` and nothing else (`swarm.rs:405`).

I built and tested a candidate fix — re-add the explicit peer and force a topic re-subscribe on `SlowPeer` — and **it did not restore delivery**, so I'm deliberately not proposing it. Recovery probably needs a connection-level reset (disconnect + redial).

There's an interaction worth naming: this PR makes large payloads actually get transmitted, and large payloads are implicated in the wedge. Nothing here *creates* the wedge — it exists today at 18 KB — but I wouldn't lean on multi-hundred-KB syncs until #2 is understood.

---

## Verification

![Before and after](https://raw.githubusercontent.com/decentpaste/decentpaste/assets/uremot-e2e/img/04-fix.png)

Live re-test after the fix, two paired peers, driven from the host:

![Live re-test](https://raw.githubusercontent.com/decentpaste/decentpaste/assets/uremot-e2e/img/05-verify.png)

Measured sync latency after the change: **8.3 ms min, 10.1 ms median**, 115.8 ms for a 500 KB payload.

---

## Reviewing this

Four commits, each independently readable:

| commit | what |
|---|---|
| `79c6976` | `fix(network): make the advertised 1MB clipboard limit real` |
| `4632d14` | `fix(clipboard): register echo guard before writing the clipboard` |
| `71bf757` | `fix(vault): stop syncing and wipe key material when the vault locks` |
| `3d53510` | `fix(clipboard): apply the echo guard to the offline-sync path too` |

Things I'd especially like a second opinion on:

1. **2 MiB `max_transmit_size`** is a judgement call, not a measurement. It's sized so the advertised 1 MB fits after base64 + envelope. Happy to make it tighter.
2. **The wire-format break** — does this warrant a protocol version bump?
3. **Lock semantics.** "Lock stops syncing" was a deliberate product choice: it's the strongest reading of a lock screen, but it does mean the auto-lock timer now pauses background sync until the user unlocks. If that's the wrong trade for this app, the alternative is to keep syncing and instead make persistence not depend on an open vault.

No tests were added because the repo has none and these behaviours need two live peers; the reproduction recipe is in the comments below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XXg2AngyJon1UuiGeYmT9U
