### PR TITLE
feat(decentsecret): make the keyring service name optionally configurable

### DIFF
--- a/decentpaste-app/tauri-plugin-decentsecret/src/desktop.rs
+++ b/decentpaste-app/tauri-plugin-decentsecret/src/desktop.rs
@@ -13,9 +13,6 @@ use tracing::{debug, error, info, warn};
 use crate::error::Error;
 use crate::models::*;
 
-/// Service name used for keyring entries.
-const SERVICE_NAME: &str = "com.decentpaste.vault";
-
 /// Account name (username) for the keyring entry.
 const ACCOUNT_NAME: &str = "vault-key";
 
@@ -23,12 +20,20 @@ const ACCOUNT_NAME: &str = "vault-key";
 pub fn init<R: Runtime, C: DeserializeOwned>(
     app: &AppHandle<R>,
     _api: PluginApi<R, C>,
+    service_name: String,
 ) -> crate::Result<Decentsecret<R>> {
-    Ok(Decentsecret(app.clone()))
+    Ok(Decentsecret {
+        _app: app.clone(),
+        service_name,
+    })
 }
 
 /// Access to the decentsecret APIs for desktop platforms.
-pub struct Decentsecret<R: Runtime>(AppHandle<R>);
+pub struct Decentsecret<R: Runtime> {
+    _app: AppHandle<R>,
+    /// Service name used for this app's keyring entries.
+    service_name: String,
+}
 
 impl<R: Runtime> Decentsecret<R> {
     /// Check what secure storage capabilities are available.
@@ -37,10 +42,10 @@ impl<R: Runtime> Decentsecret<R> {
     pub fn check_availability(&self) -> crate::Result<SecretStorageStatus> {
         debug!(
             "Checking keyring availability for service: {}",
-            SERVICE_NAME
+            self.service_name
         );
 
-        let entry = match Entry::new(SERVICE_NAME, ACCOUNT_NAME) {
+        let entry = match Entry::new(&self.service_name, ACCOUNT_NAME) {
             Ok(entry) => entry,
             Err(e) => {
                 warn!("Keyring not available: {}", e);
@@ -77,11 +82,11 @@ impl<R: Runtime> Decentsecret<R> {
         info!(
             "Attempting to store {} byte secret in keyring (service: {}, account: {})",
             secret.len(),
-            SERVICE_NAME,
+            self.service_name,
             ACCOUNT_NAME
         );
 
-        let entry = Entry::new(SERVICE_NAME, ACCOUNT_NAME).map_err(|e| {
+        let entry = Entry::new(&self.service_name, ACCOUNT_NAME).map_err(|e| {
             error!("Failed to create keyring entry: {}", e);
             Self::map_keyring_error(e)
         })?;
@@ -102,7 +107,7 @@ impl<R: Runtime> Decentsecret<R> {
 
         // Verify the secret was actually stored by creating a NEW Entry and reading back
         // This ensures we're not just reading a cached value from the original Entry
-        let verify_entry = Entry::new(SERVICE_NAME, ACCOUNT_NAME).map_err(|e| {
+        let verify_entry = Entry::new(&self.service_name, ACCOUNT_NAME).map_err(|e| {
             error!("Failed to create verification entry: {}", e);
             Self::map_keyring_error(e)
         })?;
@@ -136,10 +141,10 @@ impl<R: Runtime> Decentsecret<R> {
     pub fn retrieve_secret(&self) -> crate::Result<Vec<u8>> {
         debug!(
             "Attempting to retrieve secret from keyring (service: {}, account: {})",
-            SERVICE_NAME, ACCOUNT_NAME
+            self.service_name, ACCOUNT_NAME
         );
 
-        let entry = Entry::new(SERVICE_NAME, ACCOUNT_NAME).map_err(|e| {
+        let entry = Entry::new(&self.service_name, ACCOUNT_NAME).map_err(|e| {
             error!("Failed to create keyring entry for retrieval: {}", e);
             Self::map_keyring_error(e)
         })?;
@@ -171,10 +176,10 @@ impl<R: Runtime> Decentsecret<R> {
     pub fn delete_secret(&self) -> crate::Result<()> {
         debug!(
             "Attempting to delete secret from keyring (service: {}, account: {})",
-            SERVICE_NAME, ACCOUNT_NAME
+            self.service_name, ACCOUNT_NAME
         );
 
-        let entry = Entry::new(SERVICE_NAME, ACCOUNT_NAME).map_err(|e| {
+        let entry = Entry::new(&self.service_name, ACCOUNT_NAME).map_err(|e| {
             error!("Failed to create keyring entry for deletion: {}", e);
             Self::map_keyring_error(e)
         })?;

--- a/decentpaste-app/tauri-plugin-decentsecret/src/lib.rs
+++ b/decentpaste-app/tauri-plugin-decentsecret/src/lib.rs
@@ -8,7 +8,7 @@
 //! - **Linux**: Secret Service API (GNOME Keyring, KWallet)
 
 use tauri::{
-    plugin::{Builder, TauriPlugin},
+    plugin::{self, TauriPlugin},
     Manager, Runtime,
 };
 
@@ -41,28 +41,100 @@ impl<R: Runtime, T: Manager<R>> DecentsecretExt<R> for T {
     }
 }
 
-/// Initializes the plugin.
+/// Default desktop keyring service name.
+///
+/// Desktop keyrings (macOS Keychain, Windows Credential Manager, Linux Secret
+/// Service) are shared across the whole user account, so this value is used to
+/// namespace DecentPaste's entries. Embedding apps can override it via
+/// [`Builder::service_name`] to avoid colliding with DecentPaste's entry.
+///
+/// This is a desktop-only concern: on mobile the OS already scopes secret
+/// storage to the app (per-UID AndroidKeyStore/SharedPreferences, per-app iOS
+/// Keychain), so no service name is needed there.
+const DEFAULT_SERVICE_NAME: &str = "com.decentpaste.vault";
+
+/// Builder for the decentsecret plugin.
+///
+/// Use this when the default desktop keyring service name
+/// (`com.decentpaste.vault`) is not appropriate — for example when another
+/// application embeds this plugin and must not collide with DecentPaste's entry
+/// in the user-global desktop keyring:
+///
+/// ```ignore
+/// tauri::Builder::default()
+///     .plugin(
+///         tauri_plugin_decentsecret::Builder::new()
+///             .service_name("com.example.myapp.vault")
+///             .build(),
+///     )
+/// ```
+///
+/// The service name only affects desktop platforms; on mobile the OS scopes
+/// secret storage to the app, so the value is ignored there.
+pub struct Builder {
+    service_name: String,
+}
+
+impl Builder {
+    /// Create a new builder using the default service name (`com.decentpaste.vault`).
+    pub fn new() -> Self {
+        Self {
+            service_name: DEFAULT_SERVICE_NAME.to_string(),
+        }
+    }
+
+    /// Override the desktop keyring service name.
+    ///
+    /// Ignored on mobile, where the OS scopes secret storage to the app.
+    pub fn service_name(mut self, service_name: impl Into<String>) -> Self {
+        self.service_name = service_name.into();
+        self
+    }
+
+    /// Build the plugin.
+    pub fn build<R: Runtime>(self) -> TauriPlugin<R> {
+        let service_name = self.service_name;
+        // The service name configures the desktop keyring only; on mobile the OS
+        // scopes secret storage to the app, so the value is unused there.
+        #[cfg(mobile)]
+        let _ = service_name;
+
+        plugin::Builder::new("decentsecret")
+            .invoke_handler(tauri::generate_handler![
+                commands::check_availability,
+                commands::store_secret,
+                commands::retrieve_secret,
+                commands::delete_secret,
+            ])
+            .setup(move |app, api| {
+                #[cfg(mobile)]
+                let decentsecret = mobile::init(app, api)?;
+                #[cfg(desktop)]
+                let decentsecret = desktop::init(app, api, service_name)?;
+                app.manage(decentsecret);
+                Ok(())
+            })
+            .build()
+    }
+}
+
+impl Default for Builder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Initializes the plugin with the default desktop keyring service name.
 ///
 /// Add this to your Tauri app builder:
 /// ```ignore
 /// tauri::Builder::default()
 ///     .plugin(tauri_plugin_decentsecret::init())
 /// ```
+///
+/// To customize the desktop keyring service name, use [`Builder`] instead. The
+/// service name only applies on desktop; mobile secret stores are scoped to the
+/// app by the OS.
 pub fn init<R: Runtime>() -> TauriPlugin<R> {
-    Builder::new("decentsecret")
-        .invoke_handler(tauri::generate_handler![
-            commands::check_availability,
-            commands::store_secret,
-            commands::retrieve_secret,
-            commands::delete_secret,
-        ])
-        .setup(|app, api| {
-            #[cfg(mobile)]
-            let decentsecret = mobile::init(app, api)?;
-            #[cfg(desktop)]
-            let decentsecret = desktop::init(app, api)?;
-            app.manage(decentsecret);
-            Ok(())
-        })
-        .build()
+    Builder::new().build()
 }


### PR DESCRIPTION
I didn't write this code; Claude did, but it looks ok to me and I use it in our tauri port of Mb2. In our case, the invocation is:
```
...
        .plugin(
            // The desktop keychain item is user-global and shared across
            // builds. The release string must stay byte-identical so existing
            // installs' entries stay findable (mb2-doc#1832); the `.dev` suffix
            // gives dev builds their own vault so a dev login/logout can never
            // delete or overwrite the release credential (mb2-doc#2041).
            tauri_plugin_decentsecret::Builder::new()
                .service_name(if cfg!(debug_assertions) {
                    "com.craftpoker.vault.dev"
                } else {
                    "com.craftpoker.vault"
                })
                .build(),
        );
```
Claude chose to make it so that _you_, the authors of DecentPaste, don't need to change how you call `plugin`. The obvious downside is that it means that other people using this feature would have to know about and actively use `service_name` or by default they'd get the same service name you use, which could be an unfortunate surprise. As such, I recommend against merging the pull-request, but I'm hopeful you're sympathetic to the idea of making the service name configurable, although I recommend making the choice of the service name mandatory for everyone, including you.

So, if you close this and ask me to come up with a PR where the service name is always required, I'll be happy to do so. If you merge this PR as-is, that's fine, too.

Everything above was written by me, Cliff Matthews. Everything written below was written by Claude (as was the commit).

Desktop keyrings (macOS Keychain, Windows Credential Manager, Linux Secret Service) are shared across the whole user account, so a second application embedding this plugin would collide with DecentPaste's `com.decentpaste.vault` entry. Add a `Builder` whose `service_name` lets an embedding app namespace its own keyring entries.

The service name is a desktop-only concern: on mobile the OS already scopes secret storage to the app (per-UID AndroidKeyStore / SharedPreferences on Android, per-app Keychain access group on iOS), so no parameter is threaded through the mobile path.

Defaults are unchanged: `init()` and `Builder::new()` both use `com.decentpaste.vault`, producing byte-identical keyring identifiers for DecentPaste itself.